### PR TITLE
Print help with no args

### DIFF
--- a/bible
+++ b/bible
@@ -14,7 +14,8 @@ def parse_args():
     parser.add_argument('reference', nargs='+', help='bible reference')
     parser.add_argument('--version', nargs='?',
                         help='translation (e.g. NIV, NLT)', default=default_version)
-    parser.add_argument('--verse-numbers', action='store_true', default=False)
+    parser.add_argument('--verse-numbers', action='store_true',
+                        default=False, help='print verse numbers (hidden by default)')
     parser.add_argument('--ascii', action='store_true', default=False,
                         help='translate Unicode to ASCII (useful on Windows)')
     if len(sys.argv) == 1:

--- a/bible
+++ b/bible
@@ -8,47 +8,66 @@ from unidecode import unidecode
 
 
 def parse_args():
-    default_version = 'NIV'
+    default_version = "NIV"
     parser = argparse.ArgumentParser(
-        description='Fetch Bible references from biblegateway.com')
-    parser.add_argument('reference', nargs='+', help='bible reference')
-    parser.add_argument('--version', nargs='?',
-                        help='translation (e.g. NIV, NLT)', default=default_version)
-    parser.add_argument('--verse-numbers', action='store_true',
-                        default=False, help='print verse numbers (hidden by default)')
-    parser.add_argument('--ascii', action='store_true', default=False,
-                        help='translate Unicode to ASCII (useful on Windows)')
+        description="Fetch Bible references from biblegateway.com"
+    )
+    parser.add_argument("reference", nargs="+", help="bible reference")
+    parser.add_argument(
+        "--version",
+        nargs="?",
+        help="translation (e.g. NIV, NLT)",
+        default=default_version,
+    )
+    parser.add_argument(
+        "--verse-numbers",
+        action="store_true",
+        default=False,
+        help="print verse numbers (hidden by default)",
+    )
+    parser.add_argument(
+        "--ascii",
+        action="store_true",
+        default=False,
+        help="translate Unicode to ASCII (useful on Windows)",
+    )
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(1)
     args = parser.parse_args()
-    return ' '.join(args.reference), args.version or default_version, args.verse_numbers, args.ascii
+    return (
+        " ".join(args.reference),
+        args.version or default_version,
+        args.verse_numbers,
+        args.ascii,
+    )
 
 
 def get_soup(query, version):
     r = requests.get(
-        'https://www.biblegateway.com/passage/?search=' + query + '&version=' + version)
-    return BeautifulSoup(r.text,  "html.parser")
+        "https://www.biblegateway.com/passage/?search=" + query + "&version=" + version
+    )
+    return BeautifulSoup(r.text, "html.parser")
 
 
 def clean(tag):
-    for t in tag.find_all('sup'):
-        if show_verse_numbers and 'versenum' in t['class']:
+    for t in tag.find_all("sup"):
+        if show_verse_numbers and "versenum" in t["class"]:
             continue
         t.decompose()
     if not show_verse_numbers:
-        for t in tag.find_all(class_='chapternum'):
+        for t in tag.find_all(class_="chapternum"):
             t.decompose()
 
 
 def render(tag):
     clean(tag)
-    text = ''
+    text = ""
     for t in tag.descendants:
         if isinstance(t, str):
             text += t
-        elif t.name == 'br':
-            text += '\n'
+        elif t.name == "br":
+            text += "\n"
     return text
 
 
@@ -56,7 +75,7 @@ def get_passage(soup):
     root = soup.find(class_="result-text-style-normal")
     if root is None:
         return
-    return "\n\n".join(map(lambda t: render(t), root.select('p, div.poetry p')))
+    return "\n\n".join(map(lambda t: render(t), root.select("p, div.poetry p")))
 
 
 query, version, show_verse_numbers, use_ascii = parse_args()

--- a/bible
+++ b/bible
@@ -6,19 +6,29 @@ import argparse
 import requests
 from unidecode import unidecode
 
+
 def parse_args():
     default_version = 'NIV'
-    parser = argparse.ArgumentParser(description='Fetch Bible references from biblegateway.com')
+    parser = argparse.ArgumentParser(
+        description='Fetch Bible references from biblegateway.com')
     parser.add_argument('reference', nargs='+', help='bible reference')
-    parser.add_argument('--version', nargs='?', help='translation (e.g. NIV, NLT)', default=default_version)
+    parser.add_argument('--version', nargs='?',
+                        help='translation (e.g. NIV, NLT)', default=default_version)
     parser.add_argument('--verse-numbers', action='store_true', default=False)
-    parser.add_argument('--ascii', action='store_true', default=False, help='translate Unicode to ASCII (useful on Windows)')
+    parser.add_argument('--ascii', action='store_true', default=False,
+                        help='translate Unicode to ASCII (useful on Windows)')
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(1)
     args = parser.parse_args()
     return ' '.join(args.reference), args.version or default_version, args.verse_numbers, args.ascii
 
+
 def get_soup(query, version):
-    r = requests.get('https://www.biblegateway.com/passage/?search=' + query + '&version=' + version)
+    r = requests.get(
+        'https://www.biblegateway.com/passage/?search=' + query + '&version=' + version)
     return BeautifulSoup(r.text,  "html.parser")
+
 
 def clean(tag):
     for t in tag.find_all('sup'):
@@ -28,6 +38,7 @@ def clean(tag):
     if not show_verse_numbers:
         for t in tag.find_all(class_='chapternum'):
             t.decompose()
+
 
 def render(tag):
     clean(tag)
@@ -39,14 +50,16 @@ def render(tag):
             text += '\n'
     return text
 
+
 def get_passage(soup):
     root = soup.find(class_="result-text-style-normal")
     if root is None:
         return
-    return "\n\n".join(map(lambda t : render(t), root.select('p, div.poetry p')))
+    return "\n\n".join(map(lambda t: render(t), root.select('p, div.poetry p')))
+
 
 query, version, show_verse_numbers, use_ascii = parse_args()
-soup    = get_soup(query, version)
+soup = get_soup(query, version)
 passage = get_passage(soup).strip()
 if use_ascii:
     passage = unidecode(passage)


### PR DESCRIPTION
- Also formatted with `autopep8` unintentionally ¯\_(ツ)_/¯ 