### PR TITLE
Fixed double spaces

### DIFF
--- a/bible
+++ b/bible
@@ -82,7 +82,21 @@ def get_passages(soup):
     text = ""
     for p in passages:
         text += get_passage(p) + "\n\n"
-    return text
+    
+    chars = list(text)
+    index = 0
+    output = ""
+    for char in chars:
+        if index == 0:
+            index += 1
+            continue
+        if chars[index] == ' ' and chars[index - 1] == ' ':
+            del chars[index]
+        index += 1
+    for char in chars:
+        output += char
+    # print(text) # Old output
+    return output
 
 
 def get_passage(soup):

--- a/bible
+++ b/bible
@@ -83,20 +83,8 @@ def get_passages(soup):
     for p in passages:
         text += get_passage(p) + "\n\n"
     
-    chars = list(text)
-    index = 0
-    output = ""
-    for char in chars:
-        if index == 0:
-            index += 1
-            continue
-        if chars[index] == ' ' and chars[index - 1] == ' ':
-            del chars[index]
-        index += 1
-    for char in chars:
-        output += char
-    # print(text) # Old output
-    return output
+    x = text.replace('  ', ' ')
+    return x
 
 
 def get_passage(soup):

--- a/bible
+++ b/bible
@@ -82,9 +82,7 @@ def get_passages(soup):
     text = ""
     for p in passages:
         text += get_passage(p) + "\n\n"
-    
-    x = text.replace('  ', ' ')
-    return x
+    return text.replace('  ', ' ')
 
 
 def get_passage(soup):


### PR DESCRIPTION
This edit should get rid of double spaces. 

There are two cases that I tried:
./bible Philemon 1:4-6 --version NRSV
./bible Philemon 1:4-6 --version NKJV

These two were buggy, and now they work fine. 